### PR TITLE
Fix #1 Util.isNumber()

### DIFF
--- a/lib/util.ts
+++ b/lib/util.ts
@@ -15,7 +15,7 @@ export class Util {
       if ( !isNaN(Number(value)) ) {
         return true
       }
-      else if ( /[0-9A-F]+H/i.exec(value) ) {
+      else if ( /^[0-9A-F]+H$/i.exec(value) ) {
         return true
       }
       else {


### PR DESCRIPTION
#1 の修正です.

Util.isNumber(value)のvalueが16進数であるかどうかを判定する部分の正規表現が部分一致になっていたために, 一部のラベル名が16進数であると判断され, isNumber()の結果がtrueとなってしまっていました.
その結果, 数値ではないのに関わらず数値であると誤認されてしまい, アセンブルの際にparseInt()され, NaNが出力されています.

この問題を解決するために, 完全一致でマッチするように変更しました.

(#2 はこちらが誤ってcloseしてしまったものです. 無視してください. 申し訳ありません.)